### PR TITLE
Order of magnitude speedup for Julia implementation

### DIFF
--- a/julia/ray.jl
+++ b/julia/ray.jl
@@ -85,6 +85,6 @@ scene = create(level, SVector(0., -1., 4.), 1)
 
 function main(;n=n,scene=scene,io=stdout)
     Printf.@printf(io,"P5\n%d %d\n255", n, n)
-    write(io, image(n))
+    write(io, image(n,scene))
 end
 main()

--- a/julia/ray.jl
+++ b/julia/ray.jl
@@ -3,7 +3,7 @@
 
 import Printf
 import LinearAlgebra: dot
-using StaticArrays: SVector
+import StaticArrays: SVector
 
 struct Hit
     l ::Float64


### PR DESCRIPTION
The Julia implementation of the benchmark can be sped up significantly with low-hanging-fruit optimizations. First of all, I added const annotations to all global constants and wrapped the global scope code into a function to ensure that it actually gets compiled. I did not benchmark the code prior to those changes, since benchmarking a function in the REPL is significantly easier, but ensuring that code gets compiled instead of interpreted generally does not lead to any regressions.

After this, I got an order of magnitude speedup and an asymptotic improvement in heap memory use by replacing heap-allocated arrays with unboxed fixed-sized ones from StaticArrays.jl for your 3D vectors (keeping parameters constant). You could also use unboxed tuples here like in your OCaml implementation, or custom vector structs like in your C++ and Haskell implementations, but I ended up choosing the path of least resistance and just used a library type.